### PR TITLE
Utvider SykepengesoknadDTO med avsendertype

### DIFF
--- a/sykepengesoknad/src/main/java/no/nav/syfo/kafka/sykepengesoknad/dto/AvsendertypeDTO.java
+++ b/sykepengesoknad/src/main/java/no/nav/syfo/kafka/sykepengesoknad/dto/AvsendertypeDTO.java
@@ -1,0 +1,5 @@
+package no.nav.syfo.kafka.sykepengesoknad.dto;
+
+public enum AvsendertypeDTO {
+    BRUKER, SYSTEM
+}

--- a/sykepengesoknad/src/main/java/no/nav/syfo/kafka/sykepengesoknad/dto/SykepengesoknadDTO.java
+++ b/sykepengesoknad/src/main/java/no/nav/syfo/kafka/sykepengesoknad/dto/SykepengesoknadDTO.java
@@ -38,4 +38,5 @@ public class SykepengesoknadDTO implements Soknad {
     List<InntektskildeDTO> andreInntektskilder;
     List<SoknadsperiodeDTO> soknadsperioder;
     List<SporsmalDTO> sporsmal;
+    AvsendertypeDTO avsendertype;
 }


### PR DESCRIPTION
Trenger avsendertype for å avgjøre om en søknad er sendt av bruker eller
system. Dette brukes for å bestemme om en søknad skal merkes som
autogenerert på grunn av dødsfall i saksbehandligssystemer.