### PR TITLE
Legger til eksplisitt info om mottaker og ettersending

### DIFF
--- a/sykepengesoknad/src/main/java/no/nav/syfo/kafka/sykepengesoknad/dto/MottakerDTO.java
+++ b/sykepengesoknad/src/main/java/no/nav/syfo/kafka/sykepengesoknad/dto/MottakerDTO.java
@@ -1,7 +1,10 @@
 package no.nav.syfo.kafka.sykepengesoknad.dto;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
 public enum MottakerDTO {
     NAV,
     ARBEIDSGIVER,
-    ARBEIDSGIVER_OG_NAV
+    ARBEIDSGIVER_OG_NAV,
+    @JsonEnumDefaultValue UKJENT
 }

--- a/sykepengesoknad/src/main/java/no/nav/syfo/kafka/sykepengesoknad/dto/SykepengesoknadDTO.java
+++ b/sykepengesoknad/src/main/java/no/nav/syfo/kafka/sykepengesoknad/dto/SykepengesoknadDTO.java
@@ -39,6 +39,6 @@ public class SykepengesoknadDTO implements Soknad {
     List<SoknadsperiodeDTO> soknadsperioder;
     List<SporsmalDTO> sporsmal;
     AvsendertypeDTO avsendertype;
-    Boolean ettersending;
+    boolean ettersending;
     MottakerDTO mottaker;
 }


### PR DESCRIPTION
Både for oss og for Bømlo er det en fordel at mottaker på søknaden står eksplisitt og ikke er noe man må utlede basert på datoer for når den er sendt til arbeidsgiver/nav. Vi har i tillegg behov for å vite om det er snakk om en ettersending eller ikke. 