### PR TITLE
Legger til tidligereArbeidsgiverOrgnummer

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/sykepengesoknad/kafka/SykepengesoknadDTO.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sykepengesoknad/kafka/SykepengesoknadDTO.kt
@@ -47,5 +47,6 @@ data class SykepengesoknadDTO(
     val sendTilGosys: Boolean? = null,
     val utenlandskSykmelding: Boolean? = null,
     val medlemskapVurdering: String? = null,
-    val forstegangssoknad: Boolean? = null
+    val forstegangssoknad: Boolean? = null,
+    val tidligereArbeidsgiverOrgnummer: String? = null
 )


### PR DESCRIPTION
Legger til tidligereArbeidsgiverOrgnummer som brukes på arbeidsledig og annet søknad ved overgang fra arbeidstaker