### PR TITLE
Fjern redusert venteperiode

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/sykepengesoknad/kafka/SykepengesoknadDTO.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sykepengesoknad/kafka/SykepengesoknadDTO.kt
@@ -39,7 +39,6 @@ data class SykepengesoknadDTO(
     val egenmeldtSykmelding: Boolean? = null,
     val yrkesskade: Boolean? = null,
     val arbeidUtenforNorge: Boolean? = null,
-    val harRedusertVenteperiode: Boolean? = null,
     val behandlingsdager: List<LocalDate>? = null,
     val permitteringer: List<PeriodeDTO>? = null,
     val merknaderFraSykmelding: List<MerknadDTO>? = null,


### PR DESCRIPTION
Fjerner `harRedusertVenteperiode: Boolean? = null` fra `SykepengesoknadDTO`.

**Bakgrunn:** COVID-era felt knyttet til midlertidig forskrift om redusert arbeidsgiverperiode (mars 2020 – juli 2022). Verdien har vært `null` for alle nye søknader i over 3 år.

**Breaking change:** Konsumenter som eksplisitt refererer til `harRedusertVenteperiode` må oppdateres. Konsumenter som bruker Jackson med `FAIL_ON_UNKNOWN_PROPERTIES = false` (de fleste Nav-tjenester) er ikke berørt.

**Kjente konsumenter som må oppdateres først:**
- ~~sykepengesoknad-backend~~ (PR #1497 fjerner bruken)
- ~~sykepengesoknad-arkivering-oppgave~~ (PR #748 fjerner bruken)
- sykepenger-im-lps-api (HAG, nullable — tåler fjerning)

**Merges etter** at konsument-PR-ene er deployet.

Relatert:
- navikt/flex-sykmeldinger-backend#584
- navikt/sykepengesoknad-backend#1497
- navikt/sykepengesoknad-arkivering-oppgave#748